### PR TITLE
feat: Auto harvest advanced rebalance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ go.sum
 **/*.html
 **/*.css
 .generator/
+
+env/

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,5 +17,5 @@ optimizer_runs = 200
 solc-version = "0.8.15"
 
 libraries = [
-    'src/StructHash.sol:StructHash:0x57A694CE76eBe7A52EDb32eA5D017F2C7BBf65ad'
+    'src/StructHash.sol:StructHash:0x11F5813BC3A0E4d97B24878f6bD2601dF9A682eD'
 ]

--- a/src/StructHash.sol
+++ b/src/StructHash.sol
@@ -8,26 +8,33 @@ library StructHash {
     }
 
     // keccak256(
-    //     "RebalanceAutoCompound(RebalanceAutoCompoundAction action)RebalanceAutoCompoundAction(int256 maxGasProportionX64,int256 feeToPrincipalRatioThresholdX64)"
+    //     "RebalanceAutoCompound(RebalanceAutoCompoundAction
+    // action)RebalanceAutoCompoundAction(int256 maxGasProportionX64,int256
+    // feeToPrincipalRatioThresholdX64)"
     // );
     bytes32 constant RebalanceAutoCompound_TYPEHASH =
         0x35d8f787f18def78c8e6fcafa2acf783916baed9dc692c38b4e8a97c853b7477;
+
     struct RebalanceAutoCompound {
         RebalanceAutoCompoundAction action;
     }
+
     function _hash(RebalanceAutoCompound memory obj) internal pure returns (bytes32) {
         return keccak256(abi.encode(RebalanceAutoCompound_TYPEHASH, _hash(obj.action)));
     }
 
     // keccak256(
-    //     "RebalanceAutoCompoundAction(int256 maxGasProportionX64,int256 feeToPrincipalRatioThresholdX64)"
+    //     "RebalanceAutoCompoundAction(int256 maxGasProportionX64,int256
+    // feeToPrincipalRatioThresholdX64)"
     // );
     bytes32 constant RebalanceAutoCompoundAction_TYPEHASH =
         0x3fa522c715dd2d3373663b38d551ef7f7a5beec25a19992cd26eae7d7df39486;
+
     struct RebalanceAutoCompoundAction {
         int256 maxGasProportionX64;
         int256 feeToPrincipalRatioThresholdX64;
     }
+
     function _hash(RebalanceAutoCompoundAction memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -43,23 +50,28 @@ library StructHash {
     //     "TickOffsetCondition(uint32 gteTickOffset,uint32 lteTickOffset)"
     // );
     bytes32 constant TickOffsetCondition_TYPEHASH = 0x62a0ad438254a5fc08168ddf3cb49a0b3c0e730e76f4fa785b4df532bc2dafb9;
+
     struct TickOffsetCondition {
         uint32 gteTickOffset;
         uint32 lteTickOffset;
     }
+
     function _hash(TickOffsetCondition memory obj) internal pure returns (bytes32) {
         return keccak256(abi.encode(TickOffsetCondition_TYPEHASH, obj.gteTickOffset, obj.lteTickOffset));
     }
 
     // keccak256(
-    //     "PriceOffsetCondition(uint32 baseToken,uint256 gteOffsetSqrtPriceX96,uint256 lteOffsetSqrtPriceX96)"
+    //     "PriceOffsetCondition(uint32 baseToken,uint256 gteOffsetSqrtPriceX96,uint256
+    // lteOffsetSqrtPriceX96)"
     // );
     bytes32 constant PriceOffsetCondition_TYPEHASH = 0xee7cf2600f91b8ddafa790dd184ce3c665f9dc116423525b336e1edac8e07e12;
+
     struct PriceOffsetCondition {
         uint32 baseToken;
         uint256 gteOffsetSqrtPriceX96;
         uint256 lteOffsetSqrtPriceX96;
     }
+
     function _hash(PriceOffsetCondition memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -76,18 +88,25 @@ library StructHash {
     //     "TokenRatioCondition(int256 lteToken0RatioX64,int256 gteToken0RatioX64)"
     // );
     bytes32 constant TokenRatioCondition_TYPEHASH = 0x45ae7b1ead003f850829121834fe562edded567cc66a42e8315561c98a7735f9;
+
     struct TokenRatioCondition {
         int256 lteToken0RatioX64;
         int256 gteToken0RatioX64;
     }
+
     function _hash(TokenRatioCondition memory obj) internal pure returns (bytes32) {
         return keccak256(abi.encode(TokenRatioCondition_TYPEHASH, obj.lteToken0RatioX64, obj.gteToken0RatioX64));
     }
 
     // keccak256(
-    //     "Condition(string type,int160 sqrtPriceX96,int64 timeBuffer,TickOffsetCondition tickOffsetCondition,PriceOffsetCondition priceOffsetCondition,TokenRatioCondition tokenRatioCondition)PriceOffsetCondition(uint32 baseToken,uint256 gteOffsetSqrtPriceX96,uint256 lteOffsetSqrtPriceX96)TickOffsetCondition(uint32 gteTickOffset,uint32 lteTickOffset)TokenRatioCondition(int256 lteToken0RatioX64,int256 gteToken0RatioX64)"
+    //     "Condition(string type,int160 sqrtPriceX96,int64 timeBuffer,TickOffsetCondition
+    // tickOffsetCondition,PriceOffsetCondition priceOffsetCondition,TokenRatioCondition
+    // tokenRatioCondition)PriceOffsetCondition(uint32 baseToken,uint256 gteOffsetSqrtPriceX96,uint256
+    // lteOffsetSqrtPriceX96)TickOffsetCondition(uint32 gteTickOffset,uint32
+    // lteTickOffset)TokenRatioCondition(int256 lteToken0RatioX64,int256 gteToken0RatioX64)"
     // );
     bytes32 constant Condition_TYPEHASH = 0xaf36b8bda8212b5328e48351dce631ba51b3a66e23916e5bb6bbd603d2d06f08;
+
     struct Condition {
         string _type;
         int160 sqrtPriceX96;
@@ -96,6 +115,7 @@ library StructHash {
         PriceOffsetCondition priceOffsetCondition;
         TokenRatioCondition tokenRatioCondition;
     }
+
     function _hash(Condition memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -115,23 +135,28 @@ library StructHash {
     //     "TickOffsetAction(uint32 tickLowerOffset,uint32 tickUpperOffset)"
     // );
     bytes32 constant TickOffsetAction_TYPEHASH = 0xf5f25bd65589108507b815014b323a5f159027eba9a477039a198a5f7fc368fc;
+
     struct TickOffsetAction {
         uint32 tickLowerOffset;
         uint32 tickUpperOffset;
     }
+
     function _hash(TickOffsetAction memory obj) internal pure returns (bytes32) {
         return keccak256(abi.encode(TickOffsetAction_TYPEHASH, obj.tickLowerOffset, obj.tickUpperOffset));
     }
 
     // keccak256(
-    //     "PriceOffsetAction(uint32 baseToken,int160 lowerOffsetSqrtPriceX96,int160 upperOffsetSqrtPriceX96)"
+    //     "PriceOffsetAction(uint32 baseToken,int160 lowerOffsetSqrtPriceX96,int160
+    // upperOffsetSqrtPriceX96)"
     // );
     bytes32 constant PriceOffsetAction_TYPEHASH = 0x0a6de33fb4ce9e036ea5aa72e73288d926400e8cc438f63c7c1c84b392c5801c;
+
     struct PriceOffsetAction {
         uint32 baseToken;
         int160 lowerOffsetSqrtPriceX96;
         int160 upperOffsetSqrtPriceX96;
     }
+
     function _hash(PriceOffsetAction memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -148,27 +173,40 @@ library StructHash {
     //     "TokenRatioAction(uint32 tickWidth,int256 token0RatioX64)"
     // );
     bytes32 constant TokenRatioAction_TYPEHASH = 0x2d91584261cab64f66268846e106be0b9e325f19b0457d3be9790bff2e4d9259;
+
     struct TokenRatioAction {
         uint32 tickWidth;
         int256 token0RatioX64;
     }
+
     function _hash(TokenRatioAction memory obj) internal pure returns (bytes32) {
         return keccak256(abi.encode(TokenRatioAction_TYPEHASH, obj.tickWidth, obj.token0RatioX64));
     }
 
     // keccak256(
-    //     "RebalanceAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,string type,TickOffsetAction tickOffsetAction,PriceOffsetAction priceOffsetAction,TokenRatioAction tokenRatioAction)PriceOffsetAction(uint32 baseToken,int160 lowerOffsetSqrtPriceX96,int160 upperOffsetSqrtPriceX96)TickOffsetAction(uint32 tickLowerOffset,uint32 tickUpperOffset)TokenRatioAction(uint32 tickWidth,int256 token0RatioX64)"
+    //     "RebalanceAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,string
+    // gteType,TickOffsetAction tickOffsetGteAction,PriceOffsetAction priceOffsetGteAction,TokenRatioAction
+    // tokenRatioGteAction,string lteType,TickOffsetAction tickOffsetLteAction,PriceOffsetAction
+    // priceOffsetLteAction,TokenRatioAction tokenRatioLteAction)PriceOffsetAction(uint32 baseToken,int160
+    // lowerOffsetSqrtPriceX96,int160 upperOffsetSqrtPriceX96)TickOffsetAction(uint32 tickLowerOffset,uint32
+    // tickUpperOffset)TokenRatioAction(uint32 tickWidth,int256 token0RatioX64)"
     // );
-    bytes32 constant RebalanceAction_TYPEHASH = 0xe862ada4db7ad1d390d5445cf9eae9093553a68a1c33bdc043a9b9868c555579;
+    bytes32 constant RebalanceAction_TYPEHASH = 0xebc88669d89a68bc83eee542c09a3d91d8ce9c0af1c90d0ac3f8ff8ade2b9c50;
+
     struct RebalanceAction {
         int256 maxGasProportionX64;
         int256 swapSlippageX64;
         int256 liquiditySlippageX64;
-        string _type;
-        TickOffsetAction tickOffsetAction;
-        PriceOffsetAction priceOffsetAction;
-        TokenRatioAction tokenRatioAction;
+        string gteType;
+        TickOffsetAction tickOffsetGteAction;
+        PriceOffsetAction priceOffsetGteAction;
+        TokenRatioAction tokenRatioGteAction;
+        string lteType;
+        TickOffsetAction tickOffsetLteAction;
+        PriceOffsetAction priceOffsetLteAction;
+        TokenRatioAction tokenRatioLteAction;
     }
+
     function _hash(RebalanceAction memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -177,24 +215,42 @@ library StructHash {
                     obj.maxGasProportionX64,
                     obj.swapSlippageX64,
                     obj.liquiditySlippageX64,
-                    keccak256(bytes(obj._type)),
-                    _hash(obj.tickOffsetAction),
-                    _hash(obj.priceOffsetAction),
-                    _hash(obj.tokenRatioAction)
+                    keccak256(bytes(obj.gteType)),
+                    _hash(obj.tickOffsetGteAction),
+                    _hash(obj.priceOffsetGteAction),
+                    _hash(obj.tokenRatioGteAction),
+                    keccak256(bytes(obj.lteType)),
+                    _hash(obj.tickOffsetLteAction),
+                    _hash(obj.priceOffsetLteAction),
+                    _hash(obj.tokenRatioLteAction)
                 )
             );
     }
 
     // keccak256(
-    //     "RebalanceConfig(Condition rebalanceCondition,RebalanceAction rebalanceAction,RebalanceAutoCompound autoCompound,bool recurring)Condition(string type,int160 sqrtPriceX96,int64 timeBuffer,TickOffsetCondition tickOffsetCondition,PriceOffsetCondition priceOffsetCondition,TokenRatioCondition tokenRatioCondition)PriceOffsetAction(uint32 baseToken,int160 lowerOffsetSqrtPriceX96,int160 upperOffsetSqrtPriceX96)PriceOffsetCondition(uint32 baseToken,uint256 gteOffsetSqrtPriceX96,uint256 lteOffsetSqrtPriceX96)RebalanceAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,string type,TickOffsetAction tickOffsetAction,PriceOffsetAction priceOffsetAction,TokenRatioAction tokenRatioAction)RebalanceAutoCompound(RebalanceAutoCompoundAction action)RebalanceAutoCompoundAction(int256 maxGasProportionX64,int256 feeToPrincipalRatioThresholdX64)TickOffsetAction(uint32 tickLowerOffset,uint32 tickUpperOffset)TickOffsetCondition(uint32 gteTickOffset,uint32 lteTickOffset)TokenRatioAction(uint32 tickWidth,int256 token0RatioX64)TokenRatioCondition(int256 lteToken0RatioX64,int256 gteToken0RatioX64)"
+    //     "RebalanceConfig(Condition rebalanceCondition,RebalanceAction rebalanceAction,RebalanceAutoCompound
+    // autoCompound,bool recurring)Condition(string type,int160 sqrtPriceX96,int64 timeBuffer,TickOffsetCondition
+    // tickOffsetCondition,PriceOffsetCondition priceOffsetCondition,TokenRatioCondition
+    // tokenRatioCondition)PriceOffsetAction(uint32 baseToken,int160 lowerOffsetSqrtPriceX96,int160
+    // upperOffsetSqrtPriceX96)PriceOffsetCondition(uint32 baseToken,uint256 gteOffsetSqrtPriceX96,uint256
+    // lteOffsetSqrtPriceX96)RebalanceAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256
+    // liquiditySlippageX64,string gteType,TickOffsetAction tickOffsetGteAction,PriceOffsetAction
+    // priceOffsetGteAction,TokenRatioAction tokenRatioGteAction,string lteType,TickOffsetAction
+    // tickOffsetLteAction,PriceOffsetAction priceOffsetLteAction,TokenRatioAction
+    // tokenRatioLteAction)RebalanceAutoCompound(RebalanceAutoCompoundAction action)RebalanceAutoCompoundAction(int256
+    // maxGasProportionX64,int256 feeToPrincipalRatioThresholdX64)TickOffsetAction(uint32 tickLowerOffset,uint32
+    // tickUpperOffset)TickOffsetCondition(uint32 gteTickOffset,uint32 lteTickOffset)TokenRatioAction(uint32
+    // tickWidth,int256 token0RatioX64)TokenRatioCondition(int256 lteToken0RatioX64,int256 gteToken0RatioX64)"
     // );
-    bytes32 constant RebalanceConfig_TYPEHASH = 0xa595ef3200e4f62a94e521635728388988c00fa41a2fe6662a35a989b84c8507;
+    bytes32 constant RebalanceConfig_TYPEHASH = 0x5f178dbce6f823ba62e942b9f8ac91282fdf80cd2ad6ada0ee71a16dd42f3b12;
+
     struct RebalanceConfig {
         Condition rebalanceCondition;
         RebalanceAction rebalanceAction;
         RebalanceAutoCompound autoCompound;
         bool recurring;
     }
+
     function _hash(RebalanceConfig memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -212,11 +268,13 @@ library StructHash {
     //     "RangeOrderCondition(bool zeroToOne,int32 gteTickAbsolute,int32 lteTickAbsolute)"
     // );
     bytes32 constant RangeOrderCondition_TYPEHASH = 0xb6800e34595dae872617c5005f10a6a9e2b6a2520654db474bf4750fdd70a0c8;
+
     struct RangeOrderCondition {
         bool zeroToOne;
         int32 gteTickAbsolute;
         int32 lteTickAbsolute;
     }
+
     function _hash(RangeOrderCondition memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -225,14 +283,17 @@ library StructHash {
     }
 
     // keccak256(
-    //     "RangeOrderAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 withdrawSlippageX64)"
+    //     "RangeOrderAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256
+    // withdrawSlippageX64)"
     // );
     bytes32 constant RangeOrderAction_TYPEHASH = 0xf512215c27c5930c08d4f9d3f8d89d9b5735fb786bebf2231b3e88df5c4015d9;
+
     struct RangeOrderAction {
         int256 maxGasProportionX64;
         int256 swapSlippageX64;
         int256 withdrawSlippageX64;
     }
+
     function _hash(RangeOrderAction memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -246,13 +307,18 @@ library StructHash {
     }
 
     // keccak256(
-    //     "RangeOrderConfig(RangeOrderCondition condition,RangeOrderAction action)RangeOrderAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 withdrawSlippageX64)RangeOrderCondition(bool zeroToOne,int32 gteTickAbsolute,int32 lteTickAbsolute)"
+    //     "RangeOrderConfig(RangeOrderCondition condition,RangeOrderAction
+    // action)RangeOrderAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256
+    // withdrawSlippageX64)RangeOrderCondition(bool zeroToOne,int32 gteTickAbsolute,int32
+    // lteTickAbsolute)"
     // );
     bytes32 constant RangeOrderConfig_TYPEHASH = 0x896dec1198540e9a29dda867832b7bb119f2cec50527c0f5ee63ef305b0f539a;
+
     struct RangeOrderConfig {
         RangeOrderCondition condition;
         RangeOrderAction action;
     }
+
     function _hash(RangeOrderConfig memory obj) internal pure returns (bytes32) {
         return keccak256(abi.encode(RangeOrderConfig_TYPEHASH, _hash(obj.condition), _hash(obj.action)));
     }
@@ -261,9 +327,11 @@ library StructHash {
     //     "FeeBasedCondition(int256 minFeeEarnedUsdX64)"
     // );
     bytes32 constant FeeBasedCondition_TYPEHASH = 0x0db5bdb29ccc0083eec5fc69273aba7a8fa98c12cb39bfa1377ade34a3b76e41;
+
     struct FeeBasedCondition {
         int256 minFeeEarnedUsdX64;
     }
+
     function _hash(FeeBasedCondition memory obj) internal pure returns (bytes32) {
         return keccak256(abi.encode(FeeBasedCondition_TYPEHASH, obj.minFeeEarnedUsdX64));
     }
@@ -272,23 +340,29 @@ library StructHash {
     //     "TimeBasedCondition(int256 intervalInSecond)"
     // );
     bytes32 constant TimeBasedCondition_TYPEHASH = 0xf75b2fc8dbd0e2a1eccdee6280f192941a296b909b47921d1a7c7cfd48993252;
+
     struct TimeBasedCondition {
         int256 intervalInSecond;
     }
+
     function _hash(TimeBasedCondition memory obj) internal pure returns (bytes32) {
         return keccak256(abi.encode(TimeBasedCondition_TYPEHASH, obj.intervalInSecond));
     }
 
     // keccak256(
-    //     "AutoCompoundCondition(string type,FeeBasedCondition feeBasedCondition,TimeBasedCondition timeBasedCondition)FeeBasedCondition(int256 minFeeEarnedUsdX64)TimeBasedCondition(int256 intervalInSecond)"
+    //     "AutoCompoundCondition(string type,FeeBasedCondition feeBasedCondition,TimeBasedCondition
+    // timeBasedCondition)FeeBasedCondition(int256 minFeeEarnedUsdX64)TimeBasedCondition(int256
+    // intervalInSecond)"
     // );
     bytes32 constant AutoCompoundCondition_TYPEHASH =
         0x8077238253cf3aae9fc43bae69ede107dc9ecfe05cc3947a0cac4f94212a6223;
+
     struct AutoCompoundCondition {
         string _type;
         FeeBasedCondition feeBasedCondition;
         TimeBasedCondition timeBasedCondition;
     }
+
     function _hash(AutoCompoundCondition memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -302,14 +376,17 @@ library StructHash {
     }
 
     // keccak256(
-    //     "AutoCompoundAction(int256 maxGasProportionX64,int256 poolSlippageX64,int256 swapSlippageX64)"
+    //     "AutoCompoundAction(int256 maxGasProportionX64,int256 poolSlippageX64,int256
+    // swapSlippageX64)"
     // );
     bytes32 constant AutoCompoundAction_TYPEHASH = 0xe17b1ff10b4c0a0b457f201ae45a54a25ec9d424f9f0e068502ea1eab65d6e0e;
+
     struct AutoCompoundAction {
         int256 maxGasProportionX64;
         int256 poolSlippageX64;
         int256 swapSlippageX64;
     }
+
     function _hash(AutoCompoundAction memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -323,39 +400,56 @@ library StructHash {
     }
 
     // keccak256(
-    //     "AutoCompoundConfig(AutoCompoundCondition condition,AutoCompoundAction action)AutoCompoundAction(int256 maxGasProportionX64,int256 poolSlippageX64,int256 swapSlippageX64)AutoCompoundCondition(string type,FeeBasedCondition feeBasedCondition,TimeBasedCondition timeBasedCondition)FeeBasedCondition(int256 minFeeEarnedUsdX64)TimeBasedCondition(int256 intervalInSecond)"
+    //     "AutoCompoundConfig(AutoCompoundCondition condition,AutoCompoundAction
+    // action)AutoCompoundAction(int256 maxGasProportionX64,int256 poolSlippageX64,int256
+    // swapSlippageX64)AutoCompoundCondition(string type,FeeBasedCondition
+    // feeBasedCondition,TimeBasedCondition timeBasedCondition)FeeBasedCondition(int256
+    // minFeeEarnedUsdX64)TimeBasedCondition(int256 intervalInSecond)"
     // );
     bytes32 constant AutoCompoundConfig_TYPEHASH = 0xbf8ab0c4189cfff5a6148a64201555fddbb74f69f3c9ed9673c79357a2c77217;
+
     struct AutoCompoundConfig {
         AutoCompoundCondition condition;
         AutoCompoundAction action;
     }
+
     function _hash(AutoCompoundConfig memory obj) internal pure returns (bytes32) {
         return keccak256(abi.encode(AutoCompoundConfig_TYPEHASH, _hash(obj.condition), _hash(obj.action)));
     }
 
     // keccak256(
-    //     "AutoExitConfig(Condition condition,AutoExitAction action)AutoExitAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,address tokenOutAddress)Condition(string type,int160 sqrtPriceX96,int64 timeBuffer,TickOffsetCondition tickOffsetCondition,PriceOffsetCondition priceOffsetCondition,TokenRatioCondition tokenRatioCondition)PriceOffsetCondition(uint32 baseToken,uint256 gteOffsetSqrtPriceX96,uint256 lteOffsetSqrtPriceX96)TickOffsetCondition(uint32 gteTickOffset,uint32 lteTickOffset)TokenRatioCondition(int256 lteToken0RatioX64,int256 gteToken0RatioX64)"
+    //     "AutoExitConfig(Condition condition,AutoExitAction action)AutoExitAction(int256
+    // maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,address
+    // tokenOutAddress)Condition(string type,int160 sqrtPriceX96,int64 timeBuffer,TickOffsetCondition
+    // tickOffsetCondition,PriceOffsetCondition priceOffsetCondition,TokenRatioCondition
+    // tokenRatioCondition)PriceOffsetCondition(uint32 baseToken,uint256 gteOffsetSqrtPriceX96,uint256
+    // lteOffsetSqrtPriceX96)TickOffsetCondition(uint32 gteTickOffset,uint32
+    // lteTickOffset)TokenRatioCondition(int256 lteToken0RatioX64,int256 gteToken0RatioX64)"
     // );
     bytes32 constant AutoExitConfig_TYPEHASH = 0x12abd614ffecf2dd5f160268162f92b4228cb34287cce8936339e98be3db7a86;
+
     struct AutoExitConfig {
         Condition condition;
         AutoExitAction action;
     }
+
     function _hash(AutoExitConfig memory obj) internal pure returns (bytes32) {
         return keccak256(abi.encode(AutoExitConfig_TYPEHASH, _hash(obj.condition), _hash(obj.action)));
     }
 
     // keccak256(
-    //     "AutoExitAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,address tokenOutAddress)"
+    //     "AutoExitAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256
+    // liquiditySlippageX64,address tokenOutAddress)"
     // );
     bytes32 constant AutoExitAction_TYPEHASH = 0x335b4a1f07e5a10cc856257ff4116d238ebc816eb0189c48ede23eab0ba1b164;
+
     struct AutoExitAction {
         int256 maxGasProportionX64;
         int256 swapSlippageX64;
         int256 liquiditySlippageX64;
         address tokenOutAddress;
     }
+
     function _hash(AutoExitAction memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -370,15 +464,67 @@ library StructHash {
     }
 
     // keccak256(
-    //     "OrderConfig(RebalanceConfig rebalanceConfig,RangeOrderConfig rangeOrderConfig,AutoCompoundConfig autoCompoundConfig,AutoExitConfig autoExitConfig)AutoCompoundAction(int256 maxGasProportionX64,int256 poolSlippageX64,int256 swapSlippageX64)AutoCompoundCondition(string type,FeeBasedCondition feeBasedCondition,TimeBasedCondition timeBasedCondition)AutoCompoundConfig(AutoCompoundCondition condition,AutoCompoundAction action)AutoExitAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,address tokenOutAddress)AutoExitConfig(Condition condition,AutoExitAction action)Condition(string type,int160 sqrtPriceX96,int64 timeBuffer,TickOffsetCondition tickOffsetCondition,PriceOffsetCondition priceOffsetCondition,TokenRatioCondition tokenRatioCondition)FeeBasedCondition(int256 minFeeEarnedUsdX64)PriceOffsetAction(uint32 baseToken,int160 lowerOffsetSqrtPriceX96,int160 upperOffsetSqrtPriceX96)PriceOffsetCondition(uint32 baseToken,uint256 gteOffsetSqrtPriceX96,uint256 lteOffsetSqrtPriceX96)RangeOrderAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 withdrawSlippageX64)RangeOrderCondition(bool zeroToOne,int32 gteTickAbsolute,int32 lteTickAbsolute)RangeOrderConfig(RangeOrderCondition condition,RangeOrderAction action)RebalanceAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,string type,TickOffsetAction tickOffsetAction,PriceOffsetAction priceOffsetAction,TokenRatioAction tokenRatioAction)RebalanceAutoCompound(RebalanceAutoCompoundAction action)RebalanceAutoCompoundAction(int256 maxGasProportionX64,int256 feeToPrincipalRatioThresholdX64)RebalanceConfig(Condition rebalanceCondition,RebalanceAction rebalanceAction,RebalanceAutoCompound autoCompound,bool recurring)TickOffsetAction(uint32 tickLowerOffset,uint32 tickUpperOffset)TickOffsetCondition(uint32 gteTickOffset,uint32 lteTickOffset)TimeBasedCondition(int256 intervalInSecond)TokenRatioAction(uint32 tickWidth,int256 token0RatioX64)TokenRatioCondition(int256 lteToken0RatioX64,int256 gteToken0RatioX64)"
+    //     "AutoHarvestConfig(string type,AutoCompoundCondition condition,AutoExitAction
+    // action)AutoCompoundCondition(string type,FeeBasedCondition feeBasedCondition,TimeBasedCondition
+    // timeBasedCondition)AutoExitAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256
+    // liquiditySlippageX64,address tokenOutAddress)FeeBasedCondition(int256 minFeeEarnedUsdX64)TimeBasedCondition(int256
+    // intervalInSecond)"
     // );
-    bytes32 constant OrderConfig_TYPEHASH = 0x5697d3035f19beb9868f849a8299e5c537a4c0359a4de82d07077a2bb857f3bf;
+    bytes32 constant AutoHarvestConfig_TYPEHASH = 0x078cb4adf5687c5d8012b6cf5f2db36f84c7460eeb9ab0150aa07a1d38e72939;
+
+    struct AutoHarvestConfig {
+        string _type;
+        AutoCompoundCondition condition;
+        AutoExitAction action;
+    }
+
+    function _hash(AutoHarvestConfig memory obj) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    AutoHarvestConfig_TYPEHASH,
+                    keccak256(bytes(obj._type)),
+                    _hash(obj.condition),
+                    _hash(obj.action)
+                )
+            );
+    }
+
+    // keccak256(
+    //     "OrderConfig(RebalanceConfig rebalanceConfig,RangeOrderConfig rangeOrderConfig,AutoCompoundConfig
+    // autoCompoundConfig,AutoExitConfig autoExitConfig,AutoHarvestConfig autoHarvestConfig)AutoCompoundAction(int256
+    // maxGasProportionX64,int256 poolSlippageX64,int256 swapSlippageX64)AutoCompoundCondition(string
+    // type,FeeBasedCondition feeBasedCondition,TimeBasedCondition
+    // timeBasedCondition)AutoCompoundConfig(AutoCompoundCondition condition,AutoCompoundAction
+    // action)AutoExitAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,address
+    // tokenOutAddress)AutoExitConfig(Condition condition,AutoExitAction action)AutoHarvestConfig(string
+    // type,AutoCompoundCondition condition,AutoExitAction action)Condition(string type,int160 sqrtPriceX96,int64
+    // timeBuffer,TickOffsetCondition tickOffsetCondition,PriceOffsetCondition priceOffsetCondition,TokenRatioCondition
+    // tokenRatioCondition)FeeBasedCondition(int256 minFeeEarnedUsdX64)PriceOffsetAction(uint32 baseToken,int160
+    // lowerOffsetSqrtPriceX96,int160 upperOffsetSqrtPriceX96)PriceOffsetCondition(uint32 baseToken,uint256
+    // gteOffsetSqrtPriceX96,uint256 lteOffsetSqrtPriceX96)RangeOrderAction(int256 maxGasProportionX64,int256
+    // swapSlippageX64,int256 withdrawSlippageX64)RangeOrderCondition(bool zeroToOne,int32 gteTickAbsolute,int32
+    // lteTickAbsolute)RangeOrderConfig(RangeOrderCondition condition,RangeOrderAction action)RebalanceAction(int256
+    // maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,string gteType,TickOffsetAction
+    // tickOffsetGteAction,PriceOffsetAction priceOffsetGteAction,TokenRatioAction tokenRatioGteAction,string
+    // lteType,TickOffsetAction tickOffsetLteAction,PriceOffsetAction priceOffsetLteAction,TokenRatioAction
+    // tokenRatioLteAction)RebalanceAutoCompound(RebalanceAutoCompoundAction action)RebalanceAutoCompoundAction(int256
+    // maxGasProportionX64,int256 feeToPrincipalRatioThresholdX64)RebalanceConfig(Condition
+    // rebalanceCondition,RebalanceAction rebalanceAction,RebalanceAutoCompound autoCompound,bool
+    // recurring)TickOffsetAction(uint32 tickLowerOffset,uint32 tickUpperOffset)TickOffsetCondition(uint32
+    // gteTickOffset,uint32 lteTickOffset)TimeBasedCondition(int256 intervalInSecond)TokenRatioAction(uint32
+    // tickWidth,int256 token0RatioX64)TokenRatioCondition(int256 lteToken0RatioX64,int256 gteToken0RatioX64)"
+    // );
+    bytes32 constant OrderConfig_TYPEHASH = 0x5322f0e7ebcd51c97ec5a90f6f72372d960ae06fa718a29977e0970c6cba70aa;
+
     struct OrderConfig {
         RebalanceConfig rebalanceConfig;
         RangeOrderConfig rangeOrderConfig;
         AutoCompoundConfig autoCompoundConfig;
         AutoExitConfig autoExitConfig;
+        AutoHarvestConfig autoHarvestConfig;
     }
+
     function _hash(OrderConfig memory obj) internal pure returns (bytes32) {
         return
             keccak256(
@@ -387,15 +533,40 @@ library StructHash {
                     _hash(obj.rebalanceConfig),
                     _hash(obj.rangeOrderConfig),
                     _hash(obj.autoCompoundConfig),
-                    _hash(obj.autoExitConfig)
+                    _hash(obj.autoExitConfig),
+                    _hash(obj.autoHarvestConfig)
                 )
             );
     }
 
     // keccak256(
-    //     "Order(int64 chainId,address nfpmAddress,uint256 tokenId,string orderType,OrderConfig config,int64 signatureTime)AutoCompoundAction(int256 maxGasProportionX64,int256 poolSlippageX64,int256 swapSlippageX64)AutoCompoundCondition(string type,FeeBasedCondition feeBasedCondition,TimeBasedCondition timeBasedCondition)AutoCompoundConfig(AutoCompoundCondition condition,AutoCompoundAction action)AutoExitAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,address tokenOutAddress)AutoExitConfig(Condition condition,AutoExitAction action)Condition(string type,int160 sqrtPriceX96,int64 timeBuffer,TickOffsetCondition tickOffsetCondition,PriceOffsetCondition priceOffsetCondition,TokenRatioCondition tokenRatioCondition)FeeBasedCondition(int256 minFeeEarnedUsdX64)OrderConfig(RebalanceConfig rebalanceConfig,RangeOrderConfig rangeOrderConfig,AutoCompoundConfig autoCompoundConfig,AutoExitConfig autoExitConfig)PriceOffsetAction(uint32 baseToken,int160 lowerOffsetSqrtPriceX96,int160 upperOffsetSqrtPriceX96)PriceOffsetCondition(uint32 baseToken,uint256 gteOffsetSqrtPriceX96,uint256 lteOffsetSqrtPriceX96)RangeOrderAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 withdrawSlippageX64)RangeOrderCondition(bool zeroToOne,int32 gteTickAbsolute,int32 lteTickAbsolute)RangeOrderConfig(RangeOrderCondition condition,RangeOrderAction action)RebalanceAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,string type,TickOffsetAction tickOffsetAction,PriceOffsetAction priceOffsetAction,TokenRatioAction tokenRatioAction)RebalanceAutoCompound(RebalanceAutoCompoundAction action)RebalanceAutoCompoundAction(int256 maxGasProportionX64,int256 feeToPrincipalRatioThresholdX64)RebalanceConfig(Condition rebalanceCondition,RebalanceAction rebalanceAction,RebalanceAutoCompound autoCompound,bool recurring)TickOffsetAction(uint32 tickLowerOffset,uint32 tickUpperOffset)TickOffsetCondition(uint32 gteTickOffset,uint32 lteTickOffset)TimeBasedCondition(int256 intervalInSecond)TokenRatioAction(uint32 tickWidth,int256 token0RatioX64)TokenRatioCondition(int256 lteToken0RatioX64,int256 gteToken0RatioX64)"
+    //     "Order(int64 chainId,address nfpmAddress,uint256 tokenId,string orderType,OrderConfig config,int64
+    // signatureTime)AutoCompoundAction(int256 maxGasProportionX64,int256 poolSlippageX64,int256
+    // swapSlippageX64)AutoCompoundCondition(string type,FeeBasedCondition feeBasedCondition,TimeBasedCondition
+    // timeBasedCondition)AutoCompoundConfig(AutoCompoundCondition condition,AutoCompoundAction
+    // action)AutoExitAction(int256 maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,address
+    // tokenOutAddress)AutoExitConfig(Condition condition,AutoExitAction action)AutoHarvestConfig(string
+    // type,AutoCompoundCondition condition,AutoExitAction action)Condition(string type,int160 sqrtPriceX96,int64
+    // timeBuffer,TickOffsetCondition tickOffsetCondition,PriceOffsetCondition priceOffsetCondition,TokenRatioCondition
+    // tokenRatioCondition)FeeBasedCondition(int256 minFeeEarnedUsdX64)OrderConfig(RebalanceConfig
+    // rebalanceConfig,RangeOrderConfig rangeOrderConfig,AutoCompoundConfig autoCompoundConfig,AutoExitConfig
+    // autoExitConfig,AutoHarvestConfig autoHarvestConfig)PriceOffsetAction(uint32 baseToken,int160
+    // lowerOffsetSqrtPriceX96,int160 upperOffsetSqrtPriceX96)PriceOffsetCondition(uint32 baseToken,uint256
+    // gteOffsetSqrtPriceX96,uint256 lteOffsetSqrtPriceX96)RangeOrderAction(int256 maxGasProportionX64,int256
+    // swapSlippageX64,int256 withdrawSlippageX64)RangeOrderCondition(bool zeroToOne,int32 gteTickAbsolute,int32
+    // lteTickAbsolute)RangeOrderConfig(RangeOrderCondition condition,RangeOrderAction action)RebalanceAction(int256
+    // maxGasProportionX64,int256 swapSlippageX64,int256 liquiditySlippageX64,string gteType,TickOffsetAction
+    // tickOffsetGteAction,PriceOffsetAction priceOffsetGteAction,TokenRatioAction tokenRatioGteAction,string
+    // lteType,TickOffsetAction tickOffsetLteAction,PriceOffsetAction priceOffsetLteAction,TokenRatioAction
+    // tokenRatioLteAction)RebalanceAutoCompound(RebalanceAutoCompoundAction action)RebalanceAutoCompoundAction(int256
+    // maxGasProportionX64,int256 feeToPrincipalRatioThresholdX64)RebalanceConfig(Condition
+    // rebalanceCondition,RebalanceAction rebalanceAction,RebalanceAutoCompound autoCompound,bool
+    // recurring)TickOffsetAction(uint32 tickLowerOffset,uint32 tickUpperOffset)TickOffsetCondition(uint32
+    // gteTickOffset,uint32 lteTickOffset)TimeBasedCondition(int256 intervalInSecond)TokenRatioAction(uint32
+    // tickWidth,int256 token0RatioX64)TokenRatioCondition(int256 lteToken0RatioX64,int256 gteToken0RatioX64)"
     // );
-    bytes32 constant Order_TYPEHASH = 0xe90c3305b073b571e7a0d9f03c551c07c8a7b94927ec80f7a2a5e4282b2153fa;
+    bytes32 constant Order_TYPEHASH = 0xc656dbf48bfae7cacbfe27eb73a9a0e9d54fb5d4a0e0a56c9302f5216de62109;
+
     struct Order {
         int64 chainId;
         address nfpmAddress;
@@ -404,6 +575,7 @@ library StructHash {
         OrderConfig config;
         int64 signatureTime;
     }
+
     function _hash(Order memory obj) internal pure returns (bytes32) {
         return
             keccak256(

--- a/src/V3Automation.sol
+++ b/src/V3Automation.sol
@@ -10,7 +10,7 @@ contract V3Automation is Pausable, Common, EIP712 {
     bytes32 public constant OPERATOR_ROLE = keccak256('OPERATOR_ROLE');
     mapping(bytes32 => bool) _cancelledOrder;
 
-    constructor() EIP712('V3AutomationOrder', '4.0') {}
+    constructor() EIP712('V3AutomationOrder', '5.0') {}
 
     function initialize(
         address _swapRouter,
@@ -26,7 +26,8 @@ contract V3Automation is Pausable, Common, EIP712 {
     enum Action {
         AUTO_ADJUST,
         AUTO_EXIT,
-        AUTO_COMPOUND
+        AUTO_COMPOUND,
+        AUTO_HARVEST
     }
 
     struct ExecuteState {
@@ -301,7 +302,7 @@ contract V3Automation is Pausable, Common, EIP712 {
                 result.added0,
                 result.added1
             );
-        } else if (params.action == Action.AUTO_EXIT) {
+        } else if (params.action == Action.AUTO_EXIT || params.action == Action.AUTO_HARVEST) {
             IWETH9 weth = _getWeth9(params.nfpm, params.protocol);
             uint256 targetAmount;
             if (state.token0 != params.targetToken) {

--- a/test/integration/Common.t.sol
+++ b/test/integration/Common.t.sol
@@ -12,7 +12,7 @@ contract CommonTest is IntegrationTestBase {
         (address userAddress,) = makeAddrAndKey("random user 1");
         vm.prank(userAddress);
         vm.expectRevert();
-        address[] memory nfpms;
+        address[] memory nfpms = new address[](1);
         nfpms[0] = userAddress;
         v3utils.setWhitelistNfpm(nfpms, true);
     }

--- a/test/integration/V3Automation.t.sol
+++ b/test/integration/V3Automation.t.sol
@@ -284,4 +284,52 @@ contract V3AutomationIntegrationTest is IntegrationTestBase {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
         signature = abi.encodePacked(r, s, v);
     }
+
+    function testAutoHarvest() external {
+        _increaseLiquidity();
+
+        (address userAddress, uint256 privateKey) = makeAddrAndKey('positionOwnerAddress');
+        vm.startPrank(TEST_NFT_ACCOUNT);
+        NPM.safeTransferFrom(TEST_NFT_ACCOUNT, userAddress, TEST_NFT);
+        vm.stopPrank();
+
+        bytes memory signature = _signOrder(emptyUserConfig, privateKey);
+
+        V3Automation.ExecuteParams memory params = V3Automation.ExecuteParams(
+            V3Automation.Action.AUTO_HARVEST,
+            Common.Protocol.UNI_V3,
+            NPM,
+            TEST_NFT,
+            0,
+            address(0),
+            0,
+            0,
+            '',
+            0,
+            0,
+            '',
+            0,
+            0,
+            block.timestamp,
+            0,
+            0,
+            0,
+            0,
+            0,
+            true,
+            0,
+            0,
+            abi.encode(emptyUserConfig),
+            signature
+        );
+
+        // using approve / execute pattern
+        vm.prank(userAddress);
+        NPM.setApprovalForAll(address(v3automation), true);
+
+        vm.prank(TEST_OWNER_ACCOUNT);
+
+        // Execute auto harvest
+        v3automation.execute(params);
+    }
 }

--- a/test/integration/V3Utils.t.sol
+++ b/test/integration/V3Utils.t.sol
@@ -359,7 +359,7 @@ contract V3UtilsIntegrationTest is IntegrationTestBase {
         assertEq(countAfter, countBefore); // nft returned
     }
 
-    function testFailEmptySwapAndIncreaseLiquidity() external {
+    function testRevertIfEmptySwapAndIncreaseLiquidity() external {
         V3Utils.SwapAndIncreaseLiquidityParams memory params = Common.SwapAndIncreaseLiquidityParams(
             Common.Protocol.UNI_V3,
             NPM,
@@ -382,6 +382,9 @@ contract V3UtilsIntegrationTest is IntegrationTestBase {
         );
 
         vm.prank(TEST_NFT_ACCOUNT);
+
+        // Expect the transaction to revert
+        vm.expectRevert();
         v3utils.swapAndIncreaseLiquidity(params);
     }
 
@@ -509,7 +512,7 @@ contract V3UtilsIntegrationTest is IntegrationTestBase {
         v3utils.swapAndIncreaseLiquidity(params);
     }
 
-    function testFailEmptySwapAndMint() external {
+    function testRevertEmptySwapAndMint() external {
         V3Utils.SwapAndMintParams memory params = Common.SwapAndMintParams(
             Common.Protocol.UNI_V3,
             NPM,
@@ -536,6 +539,7 @@ contract V3UtilsIntegrationTest is IntegrationTestBase {
         );
 
         vm.prank(TEST_NFT_ACCOUNT);
+        vm.expectRevert();
         v3utils.swapAndMint(params);
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces `AUTO_HARVEST` execution path and `AutoHarvestConfig`, restructures `RebalanceAction` to gte/lte fields, updates EIP712 domain/version and related type hashes, and adds/adjusts integration tests.
> 
> - **Contracts**:
>   - **`V3Automation`**:
>     - Add `Action.AUTO_HARVEST` and handle it like `AUTO_EXIT` (swap to `targetToken` and transfer to owner).
>     - Bump EIP712 domain version to `5.0`.
>   - **`StructHash`**:
>     - Add `AutoHarvestConfig` type and include `autoHarvestConfig` in `OrderConfig` with new `OrderConfig_TYPEHASH` and `Order_TYPEHASH`.
>     - Restructure `RebalanceAction` to split into `gteType`/`lteType` with corresponding `tickOffset*`, `priceOffset*`, `tokenRatio*` actions; update `RebalanceAction_TYPEHASH` and `RebalanceConfig_TYPEHASH`.
> - **Config**:
>   - Update Foundry `libraries` address in `foundry.toml`.
> - **Tests**:
>   - Add `testAutoHarvest` in `V3Automation.t.sol`.
>   - Improve revert semantics and expectations (rename `testFail*` -> `testRevert*`, add `vm.expectRevert()`); fix NFPM whitelist test array init.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e3b77b4d0c7da00191058603f0c530335c17354. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->