### PR TITLE
feat: Deploy new version

### DIFF
--- a/contracts.json
+++ b/contracts.json
@@ -1,4 +1,10 @@
 {
+  "1": {
+    "nfpmLib": "0x5306493ccf612bc8564b30b0cdb7ff8fbd719a95",
+    "structHash": "0xb486f83280f19cf652843b8f79e52572d589bbf9",
+    "v3Automation": "0xe25f3388771c94bd3f975523b01ee261efb6f7e8",
+    "v3Utils": "0x56fc6ac4af3007c4ae36f239cb0f8028ade73519"
+  },
   "10": {
     "nfpmLib": "0x5306493ccf612bc8564b30b0cdb7ff8fbd719a95",
     "structHash": "0xb486f83280f19cf652843b8f79e52572d589bbf9",

--- a/contracts.json
+++ b/contracts.json
@@ -2,37 +2,37 @@
   "1": {
     "nfpmLib": "0x5306493ccf612bc8564b30b0cdb7ff8fbd719a95",
     "structHash": "0xb486f83280f19cf652843b8f79e52572d589bbf9",
-    "v3Automation": "0xe25f3388771c94bd3f975523b01ee261efb6f7e8",
-    "v3Utils": "0x56fc6ac4af3007c4ae36f239cb0f8028ade73519"
+    "v3Automation": "0xf3dcf08ddce36387f176b9cfc56561287cfca6c6",
+    "v3Utils": "0xb4acbc082b5e7ded571c98ee4257778a9d784b36"
   },
   "10": {
     "nfpmLib": "0x5306493ccf612bc8564b30b0cdb7ff8fbd719a95",
     "structHash": "0xb486f83280f19cf652843b8f79e52572d589bbf9",
-    "v3Automation": "0xfd0477d9b542facc4154e775f4936d11139686f4",
-    "v3Utils": "0xb0717286fca964cb7315a95a003e1c3f0313b6de"
+    "v3Automation": "0xf3dcf08ddce36387f176b9cfc56561287cfca6c6",
+    "v3Utils": "0xb4acbc082b5e7ded571c98ee4257778a9d784b36"
   },
   "56": {
     "nfpmLib": "0x5306493ccf612bc8564b30b0cdb7ff8fbd719a95",
     "structHash": "0xb486f83280f19cf652843b8f79e52572d589bbf9",
-    "v3Automation": "0xfd0477d9b542facc4154e775f4936d11139686f4",
-    "v3Utils": "0xb0717286fca964cb7315a95a003e1c3f0313b6de"
+    "v3Automation": "0xf3dcf08ddce36387f176b9cfc56561287cfca6c6",
+    "v3Utils": "0xb4acbc082b5e7ded571c98ee4257778a9d784b36"
   },
   "137": {
     "nfpmLib": "0x5306493ccf612bc8564b30b0cdb7ff8fbd719a95",
     "structHash": "0xb486f83280f19cf652843b8f79e52572d589bbf9",
-    "v3Automation": "0xe25f3388771c94bd3f975523b01ee261efb6f7e8",
-    "v3Utils": "0x56fc6ac4af3007c4ae36f239cb0f8028ade73519"
+    "v3Automation": "0xf3dcf08ddce36387f176b9cfc56561287cfca6c6",
+    "v3Utils": "0xb4acbc082b5e7ded571c98ee4257778a9d784b36"
   },
   "8453": {
     "nfpmLib": "0x5306493ccf612bc8564b30b0cdb7ff8fbd719a95",
     "structHash": "0xb486f83280f19cf652843b8f79e52572d589bbf9",
-    "v3Automation": "0xfd0477d9b542facc4154e775f4936d11139686f4",
-    "v3Utils": "0xb0717286fca964cb7315a95a003e1c3f0313b6de"
+    "v3Automation": "0xf3dcf08ddce36387f176b9cfc56561287cfca6c6",
+    "v3Utils": "0xb4acbc082b5e7ded571c98ee4257778a9d784b36"
   },
   "42161": {
     "nfpmLib": "0x5306493ccf612bc8564b30b0cdb7ff8fbd719a95",
     "structHash": "0xb486f83280f19cf652843b8f79e52572d589bbf9",
-    "v3Automation": "0xfd0477d9b542facc4154e775f4936d11139686f4",
-    "v3Utils": "0xb0717286fca964cb7315a95a003e1c3f0313b6de"
+    "v3Automation": "0xf3dcf08ddce36387f176b9cfc56561287cfca6c6",
+    "v3Utils": "0xb4acbc082b5e7ded571c98ee4257778a9d784b36"
   }
 }

--- a/contracts.json
+++ b/contracts.json
@@ -14,8 +14,8 @@
   "137": {
     "nfpmLib": "0x5306493ccf612bc8564b30b0cdb7ff8fbd719a95",
     "structHash": "0xb486f83280f19cf652843b8f79e52572d589bbf9",
-    "v3Automation": "0xfd0477d9b542facc4154e775f4936d11139686f4",
-    "v3Utils": "0xb0717286fca964cb7315a95a003e1c3f0313b6de"
+    "v3Automation": "0xe25f3388771c94bd3f975523b01ee261efb6f7e8",
+    "v3Utils": "0x56fc6ac4af3007c4ae36f239cb0f8028ade73519"
   },
   "8453": {
     "nfpmLib": "0x5306493ccf612bc8564b30b0cdb7ff8fbd719a95",

--- a/src/Common.sol
+++ b/src/Common.sol
@@ -427,9 +427,9 @@ abstract contract Common is AccessControl, Pausable {
             unwrap
         );
         INonfungiblePositionManager.IncreaseLiquidityParams memory increaseLiquidityParams =
-        IUniV3NonfungiblePositionManager.IncreaseLiquidityParams(
-            params.tokenId, total0, total1, params.amountAddMin0, params.amountAddMin1, params.deadline
-        );
+            IUniV3NonfungiblePositionManager.IncreaseLiquidityParams(
+                params.tokenId, total0, total1, params.amountAddMin0, params.amountAddMin1, params.deadline
+            );
 
         (result.liquidity, result.added0, result.added1) = params.nfpm.increaseLiquidity(increaseLiquidityParams);
 
@@ -465,10 +465,12 @@ abstract contract Common is AccessControl, Pausable {
             total1 = params.amount1 - amountInDelta;
             total0 = params.amount0 + amountOutDelta;
         } else if (address(params.swapSourceToken) != address(0)) {
-            (uint256 amountInDelta0, uint256 amountOutDelta0) =
-                _swap(params.swapSourceToken, params.token0, params.amountIn0, params.amountOut0Min, params.swapData0, 0);
-            (uint256 amountInDelta1, uint256 amountOutDelta1) =
-                _swap(params.swapSourceToken, params.token1, params.amountIn1, params.amountOut1Min, params.swapData1, 1);
+            (uint256 amountInDelta0, uint256 amountOutDelta0) = _swap(
+                params.swapSourceToken, params.token0, params.amountIn0, params.amountOut0Min, params.swapData0, 0
+            );
+            (uint256 amountInDelta1, uint256 amountOutDelta1) = _swap(
+                params.swapSourceToken, params.token1, params.amountIn1, params.amountOut1Min, params.swapData1, 1
+            );
             total0 = params.amount0 + amountOutDelta0;
             total1 = params.amount1 + amountOutDelta1;
 
@@ -738,7 +740,7 @@ abstract contract Common is AccessControl, Pausable {
     /// the token not allow to approve 0, which means the following line code will work properly
     function _safeResetAndApprove(IERC20 token, address _spender, uint256 _value) internal {
         /// @dev omitted approve(0) result because it might fail and does not break the flow
-        address(token).call(abi.encodeWithSelector(token.approve.selector, _spender, 0));
+        (bool success,) = address(token).call(abi.encodeWithSelector(token.approve.selector, _spender, 0));
 
         /// @dev value for approval after reset must greater than 0
         require(_value > 0);

--- a/src/Common.sol
+++ b/src/Common.sol
@@ -740,7 +740,7 @@ abstract contract Common is AccessControl, Pausable {
     /// the token not allow to approve 0, which means the following line code will work properly
     function _safeResetAndApprove(IERC20 token, address _spender, uint256 _value) internal {
         /// @dev omitted approve(0) result because it might fail and does not break the flow
-        (bool success,) = address(token).call(abi.encodeWithSelector(token.approve.selector, _spender, 0));
+        address(token).call(abi.encodeWithSelector(token.approve.selector, _spender, 0));
 
         /// @dev value for approval after reset must greater than 0
         require(_value > 0);

--- a/src/V3Automation.sol
+++ b/src/V3Automation.sol
@@ -440,9 +440,7 @@ contract V3Automation is Pausable, Common, EIP712 {
             revert NotSupportedAction();
         }
 
-        address(params.nfpm).call(
-            abi.encodeWithSelector(params.nfpm.transferFrom.selector, address(this), positionOwner, params.tokenId)
-        );
+        params.nfpm.transferFrom(address(this), positionOwner, params.tokenId);
     }
 
     function _validateOrder(bytes memory abiEncodedUserOrder, bytes memory orderSignature, address actor)

--- a/src/V3Utils.sol
+++ b/src/V3Utils.sol
@@ -416,7 +416,7 @@ contract V3Utils is IERC721Receiver, Common {
         }
 
         // return token to owner (this line guarantees that token is returned to originating owner)
-        address(nfpm).call(abi.encodeWithSelector(nfpm.transferFrom.selector, address(this), from, tokenId));
+        nfpm.transferFrom(address(this), from, tokenId);
 
         return IERC721Receiver.onERC721Received.selector;
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes live deployment address mappings and alters ERC721 transfer behavior to hard-revert on failure (previously ignored `call` results), which could surface new execution failures in edge cases.
> 
> **Overview**
> **Deploy/update addresses:** `contracts.json` adds chain `1` and updates `v3Automation`/`v3Utils` addresses for existing networks.
> 
> **Stricter NFT returns:** `V3Automation` and `V3Utils` replace unchecked low-level `call`-based ERC721 transfers with direct `nfpm.transferFrom(...)`, so failures now revert instead of being silently ignored.
> 
> Minor formatting-only adjustments in `Common.sol` around `_swapAndPrepareAmounts` and `IncreaseLiquidityParams` construction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c77c8965cbfb136864943f65cafbb99f5d57c382. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->